### PR TITLE
10 samplesheet and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ GermGenie was specifically designed to analyse 16S data from clinical FFPE speci
 This tool was designed with Oxford Nanopore sequencing reads (ONT), and was not tested with any other sequencing data. The input should be a folder containing one or more samples in a fastq.gz format.
 
 ## Dependencies
-The pipeline is based on [EMU](https://github.com/treangenlab/emu). Optional QC is performed with [chopper](https://github.com/wdecoster/chopper). Data is visualized using the [Plotly library](https://plotly.com).
+The pipeline is based on [EMU](https://github.com/treangenlab/emu). 
+
+Optional QC is performed with [chopper](https://github.com/wdecoster/chopper). 
+
+Data is visualized using the [Plotly library](https://plotly.com).
 
 
 # Installation
@@ -22,6 +26,7 @@ python -m pip install GermGenie
 usage: GermGenie [-h] [--version] [--threads THREADS]
                  [--threshold THRESHOLD] [--tsv] [--nreads]
                  [--subsample SUBSAMPLE] [--top_n TOP_N]
+                 [--samplesheet SAMPLESHEET.csv]
                  [--min-length MIN_LENGTH] [--max-length MAX_LENGTH]
                  [--min-quality MIN_QUALITY]
                  fastq output db
@@ -63,7 +68,46 @@ options:
   --min-quality MIN_QUALITY, -miq MIN_QUALITY
                         Minimum average Phred quality score of reads
                         to keep. Default is to keep all reads.
+  --samplesheet SAMPLESHEET, -ss SAMPLESHEET
+                        Path to samplesheet
+                        CSV file, used for
+                        renaming and sorting
 
 Developed by Daan Brackel, Birgit Rijvers & Sander Boden @ ATLS-
 Avans
 ```
+## Optional QC
+To perform QC trimming and filtering, GermGenie uses chopper. This is optional, but GermGenie can:
+* Filter based on read length
+* Filter based on read quality
+
+Use `--min-length` or `-mil` to specify a minimum read length for reads to be kept.
+
+Use `--max-length` or `-mal` to specify a maximum read length for reads to be kept.
+
+Use `--min-quality` or `-miq` to specify a minimum read length for reads to be kept.
+
+>All reads that are filtered out will not be used as input for the taxonomic classification with EMU. 
+
+## Optional sample sorting & renaming
+To sort your samples alphanumerically in the outputs, supply a samplesheet CSV with `--samplesheet` or `-ss`. 
+
+The CSV should have 2 columns with headers "file" and "name", like this:
+
+|file|name| 
+|---|---|
+barcode_01.fastq.gz|barcode01|
+barcode_04.fastq.gz|barcode04|
+barcode_02.fastq.gz|barcode06|
+
+This way, the output will be sorted based on the name column. If you don't want to change the name of your input files, make both columns contain the same.
+
+If you want to rename your files, supply the desired name for each file in the "name" column like in the example below:
+
+|file|name| 
+|---|---|
+barcode_01.fastq.gz|sample1|
+barcode_04.fastq.gz|sample4|
+barcode_02.fastq.gz|sample6|
+
+>If you don't supply a samplesheet, your input files will not be renamed or sorted.

--- a/src/germgenie/main.py
+++ b/src/germgenie/main.py
@@ -398,6 +398,13 @@ def cli() -> argparse.Namespace:
         default=None,
         help="Minimum average Phred quality score of reads to keep. Default is to keep all reads.",
     )
+    parser.add_argument(
+        '--samplesheet',
+        '-ss',
+        type=str,
+        default=None,
+        help= "Path to samplesheet file, used for renaming and sorting"
+    )
 
     return parser.parse_args()
 

--- a/src/germgenie/main.py
+++ b/src/germgenie/main.py
@@ -3,6 +3,7 @@ import os
 import glob
 import subprocess
 import sys
+from natsort import natsorted 
 from typing import List, Dict, Tuple
 from plotly import express as px
 from plotly import graph_objects as go
@@ -92,10 +93,11 @@ def find_and_sort_samplesheet(samplesheet: str) -> pd.DataFrame:
     if not {'file', 'name'}.issubset(df.columns):
         raise ValueError("Samplesheet must contain 'file' and 'name' columns.")
 
-    df_sorted = df.sort_values('name',
-                                key=lambda col: col.str.lower().str.extract('(\d+)',
-                                expand=False).fillna('0').astype(int) if col.str.contains('\d').any() else col.str.lower())
-    return df_sorted.reset_index(drop=True)
+    # Sort with natsort library
+    df_sorted = df.iloc[natsorted(range(len(df)), 
+                key=lambda i: df['name'].iloc[i].lower())]
+
+    return df_sorted
 
 def subsample_fastq(nreads: int, fastq: str, outdir: str) -> str:
     """Subsample a fastq file

--- a/src/germgenie/main.py
+++ b/src/germgenie/main.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import glob
 import subprocess
+import sys
 from typing import List, Dict, Tuple
 from plotly import express as px
 from plotly import graph_objects as go
@@ -66,9 +67,9 @@ def find_input_files(input_dir: str) -> List[str]:
     # Find all fastq.gz files
     infiles: List[str] = glob.glob(os.path.join(input_dir, "*.gz"))
     if len(infiles) < 1:
-        # If no files are found, abort
+        # If no files are found, exit
         print("No input files found...")  # TODO: replace with logging
-        os.abort()
+        sys.exit()
     else:
         # Return list of files
         return infiles
@@ -84,7 +85,7 @@ def find_and_sort_samplesheet(samplesheet: str) -> pd.DataFrame:
     """
     if not os.path.exists(samplesheet):
         print(f"Samplesheet not found: {samplesheet}")
-        os.abort()
+        sys.exit()
 
     df = pd.read_csv(samplesheet)
 
@@ -327,6 +328,7 @@ def plot_reads_mapped(readstats: ReadMapping, name_map = None, sample_order = No
     # If a mapping is provided, rename the samples
     if name_map:
         stats['sample'] = stats['sample'].map(lambda s: name_map.get(s, s))
+    # Specify categories for correct ordering instead of lexicographically
     if sample_order:
         stats['sample'] = pd.Categorical(stats['sample'], categories=sample_order, ordered=True)
         stats = stats.sort_values('sample')
@@ -458,7 +460,7 @@ def main() -> None:
     print()
     if len(infiles) < 1:
         print("No input files found...")  # TODO: replace with logging
-        os.abort()
+        sys.exit()
 
     # If a samplesheet is provided, sort and rename files
     if args.samplesheet:

--- a/src/germgenie/main.py
+++ b/src/germgenie/main.py
@@ -259,7 +259,6 @@ def concatenate_results(output_dir: str, name_map: dict = None) -> pd.DataFrame:
     for file in glob.glob(os.path.join(output_dir, "*abundance.tsv")):
         # Read file and add sample name
         df: pd.DataFrame = pd.read_csv(file, sep="\t", skipfooter=2, engine="python")
-        # df["sample"] = "_".join(get_name(file).split("_")[:-1])
         sample_key = "_".join(get_name(file).split("_")[:-1])
         sample_name = name_map.get(sample_key, sample_key) if name_map else sample_key
         df["sample"] = sample_name
@@ -438,7 +437,7 @@ def cli() -> argparse.Namespace:
         '-ss',
         type=str,
         default=None,
-        help= "Path to samplesheet file, used for renaming and sorting"
+        help= "Path to samplesheet CSV file, used for renaming and sorting"
     )
 
     return parser.parse_args()
@@ -467,7 +466,6 @@ def main() -> None:
     # If a samplesheet is provided, sort and rename files
     if args.samplesheet:
         samplesheet_df = find_and_sort_samplesheet(args.samplesheet)
-        print(samplesheet_df)  # TODO: remove when sorting works
 
         # Create mapping to replace OG file names with string in "name" column
         name_map = dict(zip(
@@ -515,7 +513,6 @@ def main() -> None:
 
     # Plot read mapping statistics
     if args.nreads:
-        # fig, readsdf = plot_reads_mapped(readstats)
         fig, readsdf = plot_reads_mapped(readstats, name_map, sample_order)
         fig.write_html(os.path.join(args.output, "read_mapping.html"))
         # Write to tsv


### PR DESCRIPTION
Resolves #10 .

### Added functionality:
* Samplesheet support: Users can now provide a samplesheet CSV (headers "file" and "name" to map original filenames to custom sample names.
* Consistent sample naming: All downstream analyses, plots, and outputs now use the mapped sample names instead of original filenames
* Sample order preservation: The order of samples in plots and tables matches the order in the alphanumerically sorted samplesheet
* EMU output renaming: EMU output files are renamed after processing based on the mapped sample names

### How to use
If a user does not want to rename their input samples, and they don't want to sort their output based on samplenames, they should not use the `--samplesheet` or `-ss` option. 

If a user does not want to rename their input samples, but does want them to be sorted in the outputs, they have to supply a samplesheet with the same names in both columns. That way, the samples will not be renamed but will be sorted.

If a user does want to rename their samples, they have to supply the desired name in the "name" column of their samplesheet.
